### PR TITLE
removing destroyed context menu's from the DOM

### DIFF
--- a/context.js
+++ b/context.js
@@ -7,14 +7,16 @@
 var context = context || (function () {
     
 	var options = {
-		fadeSpeed: 100,
-		filter: function ($obj) {
-			// Modify $obj, Do not return
+			fadeSpeed: 100,
+			filter: function ($obj) {
+				// Modify $obj, Do not return
+			},
+			above: 'auto',
+			preventDoubleContext: true,
+			compress: false
 		},
-		above: 'auto',
-		preventDoubleContext: true,
-		compress: false
-	};
+		selectorToDropdownIdRefs = {};
+
 
 	function initialize(opts) {
 		
@@ -96,15 +98,16 @@ var context = context || (function () {
 			$menu = buildMenu(data, id);
 			
 		$('body').append($menu);
-		
+		if( $(selector) ) selectorToDropdownIdRefs[selector] = '#dropdown-' + id;
 		
 		$(document).on('contextmenu', selector, function (e) {
+			var $dd = $(selectorToDropdownIdRefs[selector]);
+
 			e.preventDefault();
 			e.stopPropagation();
 			
 			$('.dropdown-context:not(.dropdown-context-sub)').hide();
 			
-			$dd = $('#dropdown-' + id);
 			if (typeof options.above == 'boolean' && options.above) {
 				$dd.addClass('dropdown-context-up').css({
 					top: e.pageY - 20 - $('#dropdown-' + id).height(),
@@ -129,7 +132,19 @@ var context = context || (function () {
 	}
 	
 	function destroyContext(selector) {
-		$(document).off('contextmenu', selector).off('click', '.context-event');
+		if( hasContextMenuBound(selector) ) {
+	      $(document).off('contextmenu', selector).off('click', '.context-event');
+	      removeContextMenuFromDOM(selector);
+    	}
+	}
+
+	function hasContextMenuBound(selector) {
+    	return selectorToDropdownIdRefs[selector];
+  	}
+
+	function removeContextMenuFromDOM(selector) {
+		$(selectorToDropdownIdRefs[selector]).remove();
+		delete selectorToDropdownIdRefs[selector];
 	}
 	
 	return {

--- a/context.js
+++ b/context.js
@@ -132,15 +132,11 @@ var context = context || (function () {
 	}
 	
 	function destroyContext(selector) {
-		if( hasContextMenuBound(selector) ) {
+		if( selectorToDropdownIdRefs[selector] ) {
 	      $(document).off('contextmenu', selector).off('click', '.context-event');
 	      removeContextMenuFromDOM(selector);
     	}
 	}
-
-	function hasContextMenuBound(selector) {
-    	return selectorToDropdownIdRefs[selector];
-  	}
 
 	function removeContextMenuFromDOM(selector) {
 		$(selectorToDropdownIdRefs[selector]).remove();


### PR DESCRIPTION
hey jakiestfu,

Thanks for this awesome plugin btw! Hands down the best bootstrap context menu plugin I've worked with.

This pull request is to fix an issue I had with it in one of the applications I am working on.

In my use case, I have a graph consisting of nodes and edges, where each node has its own context menu. A user is constantly loading different graphs, which requires the frequent removal/addition of nodes. 

I noticed that whenever I destroyed a context menu on a node, it was not actually removing it from the DOM. Consequently my DOM would become populated with these 'ghost' context menus. This fix removes the context menu from the DOM when the destroy call is made.

Let me know what you think and if I should change anything.

Thanks!
