### PR TITLE
Provide context to 'action' function. Clean up DOM on destroy

### DIFF
--- a/context.js
+++ b/context.js
@@ -5,7 +5,7 @@
  */
 
 var context = context || (function () {
-    
+		
 	var options = {
 		fadeSpeed: 100,
 		filter: function ($obj) {
@@ -15,6 +15,8 @@ var context = context || (function () {
 		preventDoubleContext: true,
 		compress: false
 	};
+
+	var $menus = {};
 
 	function initialize(opts) {
 		
@@ -88,13 +90,16 @@ var context = context || (function () {
 		}
 		return $menu;
 	}
-
+	
 	function addContext(selector, data) {
 		
 		var d = new Date(),
 			id = d.getTime(),
 			$menu = buildMenu(data, id);
-			
+
+		this.$menus[selector] = this.$menus[selector]	|| [];
+		this.$menus[selector].push($menu);
+
 		$('body').append($menu);
 		
 		
@@ -127,15 +132,23 @@ var context = context || (function () {
 			}
 		});
 	}
-	
+
 	function destroyContext(selector) {
+		var i;
 		$(document).off('contextmenu', selector).off('click', '.context-event');
+		if (this.$menus[selector]) {
+			for (i = 0;	i < this.$menus[selector].length; i++) {
+				this.$menus[selector][i].remove()
+			}
+			this.$menus[selector] = []
+		}
 	}
 	
 	return {
 		init: initialize,
 		settings: updateOptions,
 		attach: addContext,
-		destroy: destroyContext
+		destroy: destroyContext,
+		$menus: $menus
 	};
 })();

--- a/context.js
+++ b/context.js
@@ -76,7 +76,10 @@ var context = context || (function () {
 						eventAction = data[i].action;
 					$sub.find('a').attr('id', actionID);
 					$('#' + actionID).addClass('context-event');
-					$(document).on('click', '#' + actionID, eventAction);
+					action = function(event) {
+						eventAction(event, $menu.context);
+					}
+					$(document).on('click', '#' + actionID, action);
 				}
 				$menu.append($sub);
 				if (typeof data[i].subMenu != 'undefined') {
@@ -106,6 +109,7 @@ var context = context || (function () {
 		$(document).on('contextmenu', selector, function (e) {
 			e.preventDefault();
 			e.stopPropagation();
+			$menu.context = this;
 			
 			$('.dropdown-context:not(.dropdown-context-sub)').hide();
 			


### PR DESCRIPTION
This fixes #2 by providing 'action' functions with the DOM element that was right-clicked as their second argument.

It also fixes #1 by removing context menus from the DOM on destroy.
