### PR TITLE
Menu ids can be duplicated

### DIFF
--- a/context.js
+++ b/context.js
@@ -91,8 +91,7 @@ var context = context || (function () {
 
 	function addContext(selector, data) {
 		
-		var d = new Date(),
-			id = d.getTime(),
+		var id = (Math.random() + 1).toString(36).substring(10),
 			$menu = buildMenu(data, id);
 			
 		$('body').append($menu);


### PR DESCRIPTION
When calling context.attach(...) in a loop, it could happen that two
menus will share the same ID, as it was based on date.
