### PR TITLE
Fixed SASS error while processing css

### DIFF
--- a/context.standalone.css
+++ b/context.standalone.css
@@ -76,7 +76,7 @@
 	background-image: -o-linear-gradient(top, #0088cc, #0077b3);
 	background-image: linear-gradient(to bottom, #0088cc, #0077b3);
 	background-repeat: repeat-x;
-	filter: progid: dximagetransform.microsoft.gradient(startColorstr='#ff0088cc', endColorstr='#ff0077b3', GradientType=0);
+	filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff0088cc', endColorstr='#ff0077b3', GradientType=0);
 }
 .dropdown-menu .active > a, .dropdown-menu .active > a:hover {
 	color: #ffffff;
@@ -90,8 +90,7 @@
 	background-image: -o-linear-gradient(top, #0088cc, #0077b3);
 	background-repeat: repeat-x;
 	outline: 0;
-	filter: progid
-	: dximagetransform.microsoft.gradient(startColorstr='#ff0088cc', endColorstr='#ff0077b3', GradientType=0);
+	filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff0088cc', endColorstr='#ff0077b3', GradientType=0);
 }
 .dropdown-menu .disabled > a, .dropdown-menu .disabled > a:hover {
 	color: #999999;


### PR DESCRIPTION
Currently, if you try to include context.js's css in sass, sass processor chokes on IE filter declaration.

```
Syntax error: Invalid CSS after "       filter: progid": expected ";", was ": dximagetransf..."
        on line 79 of **CUT**\app\vendor\contextjs\context.standalone.css
        from line 16 of app/themes/main.scss
```

I cleared this rule a bit, now sass can successfully process this css rule.
